### PR TITLE
Adds callback for processing violations

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,17 +12,19 @@ Cypress.Commands.add('configureAxe', (configurationOptions = {}) => {
     })
 })
 
-Cypress.Commands.add('checkA11y', (context, options) => {
+Cypress.Commands.add('checkA11y', (context, options, violationCallback) => {
   cy.window({ log: false })
     .then(win => {
       if (isEmptyObjectorNull(context)) context = undefined
       if (isEmptyObjectorNull(options)) options = undefined
+      if (isEmptyObjectorNull(violationCallback)) violationCallback = undefined
       return win.axe.run(context ? 
             context = context : 
             context = win.document, options)
     })
     .then(({ violations }) => {
       if (violations.length) {
+        if (violationCallback) violationCallback(violations)
         cy.wrap(violations, { log: false }).each(v => {
           Cypress.log({
             name: 'a11y error!',


### PR DESCRIPTION
Love cypress-axe!

One use case I've run into is processing the violations with a custom handler; a specific use-case is enhancing the terminal output. Unfortunately, the only way to currently handle them is by forking and modifying cypress-axe. I've added an argument that allows users of cypress-axe to specify a function to handle that instead. Hopefully, this helps someone else.