### PR TITLE
Highlight elements with violations

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,12 @@ Cypress.Commands.add('checkA11y', (context, options, violationCallback) => {
       if (violations.length) {
         if (violationCallback) violationCallback(violations)
         cy.wrap(violations, { log: false }).each(v => {
+          const selectors = v.nodes
+            .reduce((acc, node) => acc.concat(node.target), [])
+            .join(', ')
+        
           Cypress.log({
+            $el: Cypress.$(selectors),
             name: 'a11y error!',
             consoleProps: () => v,
             message: `${v.id} on ${v.nodes.length} Node${


### PR DESCRIPTION
We can use [`$el`](https://docs.cypress.io/api/cypress-api/cypress-log.html#Syntax) to tell Cypress which elements had violations and highlight them.

![example](https://user-images.githubusercontent.com/916905/74401273-9a47f000-4dd5-11ea-8125-b681706d0908.gif)

