### PR TITLE
update package-lock version and authorize cypress^4 peer dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-axe",
-  "version": "0.4.0",
+  "version": "0.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "peerDependencies": {
     "axe-core": "^3.1.2",
-    "cypress": "^3.1.1"
+    "cypress": "^3.1.1 | ^4.0.2"
   },
   "author": "Andy Van Slaars",
   "contributors": [


### PR DESCRIPTION
This simple PR does:
- add cypress ^4.0.2 as an authorize peer dependency
- update the package-lock

goal:
remove warning for people who moved to cypress 4+

Cypress axe works great on it, but generates warning in CLI currently