### PR TITLE
Allowed default aXe version in injectAxe command

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 Cypress.Commands.add('injectAxe', () => {
   cy.window({ log: false }).then(window => {
     const axe = require('axe-core')
-    window.eval(axe.source)
+    window.axe = axe.default || axe
   })
 })
 


### PR DESCRIPTION
Fixes #27, and brings back in the removal of `eval` from #18.