### PR TITLE
Fix peer dep.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "peerDependencies": {
     "axe-core": "^3.1.2",
-    "cypress": "^3.1.1 | ^4.0.2"
+    "cypress": "^3.1.1 || ^4.0.2"
   },
   "author": "Andy Van Slaars",
   "contributors": [


### PR DESCRIPTION
The latest release hadn't fixed the peerdep. message since two pipe symbols are required for the logical OR per https://docs.npmjs.com/misc/semver