### PR TITLE
Add the option to overwrite cy.visit to automatically include axe-core

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -73,6 +73,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "DesselBane",
+      "name": "Dessel Bane",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/12199480?s=400&u=e6e2ce88aae1cceb050c89fe90607b4dee32266f&v=4",
+      "profile": "https://github.com/DesselBane",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ beforeEach(() => {
 })
 ```
 
+### Overwrite cy.visit to include cy.injectAxe
+
+This will overwrite the `cy.visit()` command. Each time the `cy.visit()` command resolves the `axe-core` runtime is injected into the page.
+
+To overwrite the `cy.visit()` command update the `Cypress/support/index.js` file and add these lines up top:
+
+```js
+import { overwriteVisitCommand } from 'cypress-axe'
+overwriteVisitCommand()
+```
+
 ### cy.configureAxe
 
 #### Purpose

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,14 @@ export const configureAxe = (configurationOptions = {}) => {
   })
 }
 
+export const overwriteVisitCommand = () => {
+  Cypress.Commands.overwrite('visit', (originalFn, url, options = {}) => {
+    return originalFn(url, options).then((window) => {
+      window.eval(axe)
+    })
+  })
+}
+
 const checkA11y = (
   context,
   options,


### PR DESCRIPTION
Hi this is my first PR so I hope this is in the correct format

# What is the problem
Adding `cy.injectAxe()` after each `cy.visit()` is repetitive.  \
Cypress does not allow to execute a command inside the `then()` statement of another command. This means that it can't be overwritten like so:

```js
Cypress.Commands.overwrite('visit', (originalFn, url, options = {}) => {
    return originalFn(url, options).then(() => {
      cy.injectAxe()
    })
  })
```

and when overwriting it like so:

```js
Cypress.Commands.overwrite('visit', (originalFn, url, options = {}) => {
    originalFn(url, options)
    cy.injectAxe()
  })
```

The `injectAxe()` method is invoked before the original `cy.visit()` promise is resolved.

# Why implement it like this?
I figured overwriting the `cy.visit()` command should be optional since not everyone will need/want it.

