### PR TITLE
Added support for a custom message on output

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,12 +18,14 @@ const checkA11y = (
   context,
   options,
   violationCallback,
-  skipFailures = false
+  skipFailures = false,
+  message
 ) => {
   cy.window({ log: false })
     .then(win => {
       if (isEmptyObjectorNull(context)) context = undefined
       if (isEmptyObjectorNull(options)) options = undefined
+      if (isEmptyObjectorNull(message)) message = context === undefined ? '' : context
       if (isEmptyObjectorNull(violationCallback)) violationCallback = undefined
       const { includedImpacts, ...axeOptions } = options || {}
       return win.axe
@@ -39,7 +41,7 @@ const checkA11y = (
     .then(violations => {
       if (violations.length) {
         if (violationCallback) {
-          violationCallback(violations)
+          violationCallback(violations, message)
         }
         cy.wrap(violations, { log: false }).each(v => {
           const selectors = v.nodes


### PR DESCRIPTION
Added an optional message that can be passed with the call to checka11y after the skipFailures bool. This message will be set to either the message if supplied, or if not, the context if supplied, or a blank string if not. This is then passed to the violations callback, so the user has the option to do something with it when reporting violations, to allow for friendlier messaging, especially to help distinguish one call to checka11y from another. 